### PR TITLE
fix(copy,deps): move `glob` package to `dependencies`

### DIFF
--- a/.changeset/fruity-mammals-care.md
+++ b/.changeset/fruity-mammals-care.md
@@ -1,0 +1,5 @@
+---
+'@mheob/rollup-plugin-copy': patch
+---
+
+move the `glob` package from `devDependencies` to `dependencies` to use it in runtime

--- a/packages/copy/package.json
+++ b/packages/copy/package.json
@@ -25,12 +25,14 @@
 		"build": "tsup src/index.ts --clean --dts --minify --format esm",
 		"lint": "eslint . --fix"
 	},
+	"dependencies": {
+		"glob": "^11.0.2"
+	},
 	"devDependencies": {
 		"@types/node": "^22.15.12",
 		"eslint": "catalog:",
-		"glob": "^11.0.2",
 		"rollup": "^4.40.2",
-		"tsup": "^8.0.0",
+		"tsup": "^8.4.0",
 		"typescript": "catalog:"
 	},
 	"peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,6 +61,10 @@ importers:
         version: 5.8.3
 
   packages/copy:
+    dependencies:
+      glob:
+        specifier: ^11.0.2
+        version: 11.0.2
     devDependencies:
       '@types/node':
         specifier: ^22.15.12
@@ -68,14 +72,11 @@ importers:
       eslint:
         specifier: 'catalog:'
         version: 9.26.0(jiti@2.4.2)
-      glob:
-        specifier: ^11.0.2
-        version: 11.0.2
       rollup:
         specifier: ^4.40.2
         version: 4.40.2
       tsup:
-        specifier: ^8.0.0
+        specifier: ^8.4.0
         version: 8.4.0(jiti@2.4.2)(typescript@5.8.3)(yaml@2.7.1)
       typescript:
         specifier: 'catalog:'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependency configuration to ensure required packages are available at runtime.
  - Upgraded a development tool to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->